### PR TITLE
Clarify address input placeholders and add venue hint for event forms

### DIFF
--- a/index.html
+++ b/index.html
@@ -661,7 +661,8 @@
               <span><strong style="font-size:14px;color:var(--gray-800);">Keep address private</strong><br><span style="font-size:12px;color:var(--gray-600);">Visitors see city only and can request the address from you</span></span>
             </label>
           </div>
-          <input class="form-input" id="s-address" autocomplete="off" type="text" placeholder="123 Peachtree Rd, Alpharetta, GA">
+          <input class="form-input" id="s-address" autocomplete="off" type="text" placeholder="Enter full address or venue name">
+          <div class="field-hint">You can write a full street address or just the venue name</div>
           <div id="s-address-hint" style="font-size:12px; color:#5c3d10; font-weight:700; margin-top:10px; background:#fff8ee; border-left:3px solid var(--gold); border-radius:0 6px 6px 0; padding:9px 13px; line-height:1.5; display:none;"></div>
         </div>
       </div>
@@ -1001,7 +1002,8 @@
               <span><strong style="font-size:14px;color:var(--gray-800);">Keep address private</strong><br><span style="font-size:12px;color:var(--gray-600);">Visitors see city only and can request the address from you</span></span>
             </label>
           </div>
-          <input class="form-input" id="e-address" type="text" placeholder="123 Peachtree Rd, Alpharetta, GA">
+          <input class="form-input" id="e-address" type="text" placeholder="Enter full address or venue name">
+          <div class="field-hint">You can write a full street address or just the venue name</div>
           <div id="e-address-hint" style="font-size:12px; color:#5c3d10; font-weight:700; margin-top:10px; background:#fff8ee; border-left:3px solid var(--gold); border-radius:0 6px 6px 0; padding:9px 13px; line-height:1.5; display:none;"></div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Make the address fields in the event create/edit forms clearer so users know they can enter either a full street address or just a venue name.

### Description
- Update the `#s-address` and `#e-address` input placeholders to `Enter full address or venue name` and add a `.field-hint` element under each input with the text `You can write a full street address or just the venue name`.

### Testing
- No automated tests were run for this small HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01ecaf608832fba34b055df256559)