### PR TITLE
Fix event edit return flow and preserve organizer field

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,7 +780,7 @@
     <div class="site-name" onclick="showPage('page-home')">Atlanta <span>IL</span> Community Events</div>
   </div>
   <div class="page-header" style="background:linear-gradient(160deg,#1e4068,#0f2035); border-bottom:3px solid var(--gold); padding:20px 24px;">
-    <span class="back-link" id="edit-back-link" onclick="editFromAdmin ? loadAdminPage() : showPage('page-home')" style="font-size:12px; color:rgba(255,255,255,0.6); cursor:pointer; display:inline-block; margin-bottom:8px;">← Back to Admin</span>
+    <span class="back-link" id="edit-back-link" onclick="editFromAdmin ? loadAdminPage() : returnToHomeFromEdit()" style="font-size:12px; color:rgba(255,255,255,0.6); cursor:pointer; display:inline-block; margin-bottom:8px;">← Back to Admin</span>
     <h1 style="font-family:'Source Serif 4',serif; font-size:22px; font-weight:400; color:white; margin-bottom:4px;">Edit Event</h1>
     <p style="font-size:12px; color:rgba(255,255,255,0.55);">Update details below and click Save Changes. * Required fields</p>
   </div>
@@ -1074,7 +1074,7 @@
     <div class="edit-cancel-bar">
       <button class="btn-danger" onclick="openCancelConfirm()" style="display:flex; align-items:center; gap:7px;"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg> Cancel Event</button>
       <div class="btn-right">
-        <button class="btn-secondary" onclick="editFromAdmin ? loadAdminPage() : showPage('page-home')">Discard Changes</button>
+        <button class="btn-secondary" onclick="editFromAdmin ? loadAdminPage() : returnToHomeFromEdit()">Discard Changes</button>
         <button class="btn-primary" id="save-btn" onclick="saveEvent()">Save Changes →</button>
       </div>
     </div>
@@ -2022,6 +2022,7 @@ async function loadEditPage(editKey, fromAdmin = false) {
     }
     // Trigger online city handler to show/hide address section
     handleOnlineCity('e');
+    document.getElementById('e-organizer').value = e.organizer_name || '';
     document.getElementById('e-email').value = e.contact_email || '';
     document.getElementById('e-phone').value = e.contact_phone || '';
     const ePhone = document.getElementById('e-phone');
@@ -2124,7 +2125,7 @@ async function saveEvent() {
     });
     await loadEvents();
   populateYearDropdowns();
-    if (editFromAdmin) { loadAdminPage(); } else { showPage('page-home'); }
+    if (editFromAdmin) { loadAdminPage(); } else { returnToHomeFromEdit(); }
   } catch (e) {
     errDiv.textContent = 'Error saving: ' + e.message;
     errDiv.style.display = 'block';
@@ -2150,7 +2151,7 @@ async function confirmCancelEvent(action) {
     closeModal('overlay-cancel');
     await loadEvents();
   populateYearDropdowns();
-    if (editFromAdmin) { loadAdminPage(); } else { showPage('page-home'); }
+    if (editFromAdmin) { loadAdminPage(); } else { returnToHomeFromEdit(); }
   } catch (e) {
     alert('Error cancelling event: ' + e.message);
   }
@@ -2456,6 +2457,7 @@ function removeEditImage() { editFormState.imageFile = null; editFormState.remov
 // MODALS & PAGE NAV
 // ═══════════════════════════════════════════════════════════
 function showPage(id) { document.querySelectorAll('.page-view').forEach(p => p.classList.remove('active')); document.getElementById(id).classList.add('active'); window.scrollTo({top:0, behavior:'instant'}); document.body.scrollTop = 0; document.documentElement.scrollTop = 0; }
+function returnToHomeFromEdit() { history.replaceState({}, '', `${window.location.pathname}`); showPage('page-home'); }
 function closeModal(id) { document.getElementById(id).classList.remove('open'); }
 
 function shareEvent(e, id) {


### PR DESCRIPTION
### Motivation
- Users returning from the Edit page were left with the `?edit=` query param in the URL and sometimes the app failed to load the home view correctly. 
- The organizer name field could be cleared during edit because the edit form was not consistently prefilled from the loaded event record.

### Description
- Added `returnToHomeFromEdit()` which calls `history.replaceState({}, '', \\`${window.location.pathname}\\`)` and then `showPage('page-home')` to clear query params before navigating home. 
- Replaced direct `showPage('page-home')` calls on non-admin edit exit paths with `returnToHomeFromEdit()` for the edit header back link, the Discard Changes button, post-save redirect, and post-cancel redirect. 
- Restored prefill of the organizer input by setting `document.getElementById('e-organizer').value = e.organizer_name || ''` in `loadEditPage()` so the organizer name is preserved when editing.

### Testing
- Ran `git diff --check` which returned clean results. 
- Used `rg -n` searches to verify the updated call sites (`returnToHomeFromEdit`, `e-organizer`, back-link and discard button) were applied as intended. 
- Inspected the diff with `git diff` to confirm the new `returnToHomeFromEdit()` implementation and the `loadEditPage()` prefill change were present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01f65d130832f83e444bc538198a3)