### PR TITLE
Set placeholder 'COMMUNITY EVENTS' text color to white for better contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -1545,7 +1545,7 @@ function renderEventRow(e) {
           <span style="font-family:'Source Serif 4',serif; font-size:16px; font-style:italic; color:#e8b86a; font-weight:300;">IL</span>
         </div>
         <div style="width:28px; height:1px; background:rgba(200,150,62,0.4);"></div>
-        <span style="font-family:'Nunito',sans-serif; font-size:8px; color:rgba(255,255,255,0.35); letter-spacing:2px; text-transform:uppercase; text-align:center; line-height:2; font-weight:700;">COMMUNITY<br>EVENTS</span>
+        <span style="font-family:'Nunito',sans-serif; font-size:8px; color:white; letter-spacing:2px; text-transform:uppercase; text-align:center; line-height:2; font-weight:700;">COMMUNITY<br>EVENTS</span>
       </div>`;
 
   const timeStr = e.end_time ? `${formatTime(e.start_time)} - ${formatTime(e.end_time)}` : formatTime(e.start_time);
@@ -1615,7 +1615,7 @@ function openEventModal(id) {
           <span style="font-family:'Source Serif 4',serif; font-size:20px; font-style:italic; color:#e8b86a; font-weight:300;">IL</span>
         </div>
         <div style="width:32px; height:1px; background:rgba(200,150,62,0.4);"></div>
-        <span style="font-family:'Nunito',sans-serif; font-size:9px; color:rgba(255,255,255,0.35); letter-spacing:2px; text-transform:uppercase; text-align:center; line-height:2; font-weight:700;">COMMUNITY<br>EVENTS</span>
+        <span style="font-family:'Nunito',sans-serif; font-size:9px; color:white; letter-spacing:2px; text-transform:uppercase; text-align:center; line-height:2; font-weight:700;">COMMUNITY<br>EVENTS</span>
       </div>`;
 
   let addressHtml = '';


### PR DESCRIPTION
### Motivation
- Improve readability of the placeholder branding text by increasing its contrast in event cards and the event detail modal.

### Description
- Updated inline styles in `index.html` to change the `COMMUNITY EVENTS` placeholder text color from `rgba(255,255,255,0.35)` to `white` in both the event row thumbnail and the event detail modal.

### Testing
- No automated tests were modified or required for this visual-only change; the project's automated test suite was not applicable to this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0226c6d78832fa21d8c9cc90f9763)