### PR TITLE
Refresh year picker on interaction to keep current year +2 range

### DIFF
--- a/index.html
+++ b/index.html
@@ -1772,6 +1772,21 @@ function populateYearDropdowns(extraYear) {
   });
 }
 
+function refreshYearDropdownRange() {
+  const activeYear =
+    document.getElementById('e-year')?.value ||
+    document.getElementById('s-year')?.value ||
+    null;
+  populateYearDropdowns(activeYear);
+}
+
+function bindYearDropdownRefresh() {
+  document.querySelectorAll('[id$="-year"]').forEach(sel => {
+    sel.addEventListener('focus', refreshYearDropdownRange);
+    sel.addEventListener('pointerdown', refreshYearDropdownRange);
+  });
+}
+
 function buildDateValue(mid) {
   const m = document.getElementById(mid+'-month') ? document.getElementById(mid+'-month').value : '';
   const d = document.getElementById(mid+'-day') ? document.getElementById(mid+'-day').value : '';
@@ -2500,6 +2515,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   await loadEvents();
   populateYearDropdowns();
+  bindYearDropdownRefresh();
 
   if (params.has('event')) {
     const eventId = params.get('event');


### PR DESCRIPTION
### Motivation
- Ensure the event year dropdown always offers the real current year and the next two years even when the app/tab stays open across a year boundary.
- Preserve existing behavior where an edit-mode year outside the default range is still shown and selected.

### Description
- Added `refreshYearDropdownRange()` which reads any currently-selected year and calls `populateYearDropdowns()` so options are recalculated from the real current year.
- Added `bindYearDropdownRefresh()` which attaches `focus` and `pointerdown` listeners to all `[id$="-year"]` selects to refresh options on user interaction.
- Called `bindYearDropdownRefresh()` during app init after `populateYearDropdowns()` so the behavior is active when the page loads.
- Kept existing logic in `populateYearDropdowns(extraYear)` so chosen year is preserved when possible (including edit flow).

### Testing
- Ran code searches (`rg`) to locate year-picker usages and confirm the new helper is hooked into the right places, and those checks succeeded.
- Inspected the updated `index.html` diff to verify the inserted functions and the init binding; the diff shows the new functions and the `bindYearDropdownRefresh()` call.
- Performed basic file inspections of the modified lines to ensure correct placement and syntax; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01dfb3848832fb46a23203b237c2c)