### PR TITLE
Set homepage events view default to All Upcoming

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,13 +354,13 @@
   <div class="filter-bar">
     <span class="filter-label">Filter:</span>
     <div class="filter-chip" id="chip-date" onclick="toggleDropdown('dd-date', event)">
-      <span id="date-label">Date</span> ▾
+      <span id="date-label">All Upcoming</span> ▾
       <div class="dropdown-menu" id="dd-date">
         <div class="dropdown-item" onclick="setDateFilter('this-week','This Week',event)">This Week</div>
         <div class="dropdown-item" onclick="setDateFilter('this-weekend','This Weekend',event)">This Weekend</div>
         <div class="dropdown-item" onclick="setDateFilter('next-week','Next Week',event)">Next Week</div>
         <div class="dropdown-item" onclick="setDateFilter('this-month','This Month',event)">This Month</div>
-        <div class="dropdown-item" onclick="setDateFilter('all','All Upcoming',event)">All Upcoming</div>
+        <div class="dropdown-item selected" onclick="setDateFilter('all','All Upcoming',event)">All Upcoming</div>
       </div>
     </div>
     <div class="filter-chip" id="chip-city" onclick="toggleDropdown('dd-city', event)">
@@ -2235,7 +2235,7 @@ function setAudienceFilter(value, label, e) { e.stopPropagation(); filters.audie
 function updateFilterChip(id, active) { document.getElementById(id).classList.toggle('active', active); }
 function updateDropdownSelected(ddId, label) { document.querySelectorAll(`#${ddId} .dropdown-item`).forEach(i => i.classList.toggle('selected', i.textContent.trim() === label)); }
 function closeAllDropdowns() { document.querySelectorAll('.filter-chip').forEach(c => c.classList.remove('open')); }
-function clearFilters() { filters = { date: 'all', city: 'all', type: 'all', cost: 'all', audience: 'all' }; document.getElementById('date-label').textContent = 'Date'; document.getElementById('city-label').textContent = 'City'; document.getElementById('type-label').textContent = 'Event Type'; document.getElementById('cost-label').textContent = 'Cost'; document.getElementById('audience-label').textContent = 'For'; document.getElementById('chip-date').classList.remove('active'); ['chip-city','chip-type','chip-cost','chip-audience'].forEach(id => document.getElementById(id).classList.remove('active')); renderEvents(); }
+function clearFilters() { filters = { date: 'all', city: 'all', type: 'all', cost: 'all', audience: 'all' }; document.getElementById('date-label').textContent = 'All Upcoming'; document.getElementById('city-label').textContent = 'City'; document.getElementById('type-label').textContent = 'Event Type'; document.getElementById('cost-label').textContent = 'Cost'; document.getElementById('audience-label').textContent = 'For'; document.getElementById('chip-date').classList.remove('active'); ['chip-city','chip-type','chip-cost','chip-audience'].forEach(id => document.getElementById(id).classList.remove('active')); updateDropdownSelected('dd-date', 'All Upcoming'); renderEvents(); }
 
 function toggleDropdown(id, e) {
   e.stopPropagation();


### PR DESCRIPTION
### Motivation
- The home page should default to showing "All Upcoming" events when users first visit, instead of a generic `Date` placeholder.

### Description
- Updated the date filter label text to `All Upcoming` on the home page by changing the `#date-label` span content.
- Marked the `All Upcoming` dropdown item as selected by adding the `selected` class to that `div` in the date menu.
- Updated `clearFilters()` to reset the date label back to `All Upcoming` and call `updateDropdownSelected('dd-date','All Upcoming')` so the UI selection is consistent.

### Testing
- Served the site locally with `python3 -m http.server 4173` and verified the page loads successfully at `http://127.0.0.1:4173/index.html`.
- Ran a Playwright script to open the homepage and capture a screenshot of the filter state, which confirmed `All Upcoming` is shown as the default; the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01cd0dfcc832f99e118ede85f36dc)